### PR TITLE
Spellcheck & Markdown Fixes

### DIFF
--- a/cSpell.json
+++ b/cSpell.json
@@ -9,9 +9,12 @@
         "Giscus",
         "Namecheap",
         "tada",
-        "prepending"
+        "prepending",
+        "pseudocode"
     ],
-    "ignoreWords": [],
+    "ignoreWords": [
+        "Sheeran"
+    ],
     "ignoreRegExpList": [
         "\\((.*)\\)", // Markdown links
         "uid: (.*)", // uid lines,

--- a/cSpell.json
+++ b/cSpell.json
@@ -8,7 +8,8 @@
         "Excella",
         "Giscus",
         "Namecheap",
-        "tada"
+        "tada",
+        "prepending"
     ],
     "ignoreWords": [],
     "ignoreRegExpList": [

--- a/docs/_posts/2023-03-29-functional-modularity-1.md
+++ b/docs/_posts/2023-03-29-functional-modularity-1.md
@@ -201,7 +201,7 @@ Thanks for taking this journey with me. Questions? Comments? I would love to con
       
       Imperative object-oriented code is what I learned in school and used for years, and my personal mileage with it is that you can be productive quickly but a functional approach can help prevent issues with shared mutable state and other pitfalls that are easy to fall into when you scale your programs.
 
-[^3]: The operator’s name ‘cons’ in Scala is in homage to the cons cell data structure used as the basis for collections in many Lisp family languages. More information can be found [here](https://en.wikipedia.org/wiki/Cons#:~:text=In%20computer%20programming%2C%20cons%20(%2F,%2C%20or%20(cons)%20pairs.)
+[^3]: The operator’s name ‘cons’ in Scala is in homage to the cons cell data structure used as the basis for collections in many Lisp family languages. More information can be found [here](<https://en.wikipedia.org/wiki/Cons#:~:text=In%20computer%20programming%2C%20cons%20(%2F,%2C%20or%20(cons)%20pairs.>)
 
 [^4]: Even though this article and the John Hughes memo will refer to 'cons' as though it were implemented entirely with functions, it usually isn't in practice. Scala uses a case class and factory method to build a list and hold it in memory, and it isn't alone. Lisp and other functional languages have opted for data structures because a truly stateless functional approach isn't as performant. For more on proving the 'cons' interface can be implemented solely with functions, see the reference to Church Encoding [here](https://en.wikipedia.org/wiki/Cons)
 

--- a/docs/_posts/2023-03-29-functional-modularity-1.md
+++ b/docs/_posts/2023-03-29-functional-modularity-1.md
@@ -125,7 +125,7 @@ These examples require authoring an entirely new function each time, but the pat
 (1.*(2)).*(3) // * is a function in scala
 ```
 
-but the trickier part is that recursive pattern. It turns out scala has a function for that too in the function 'foldRight'. Folding is a conventional name in most functional languages for a class of higher order functions that combine the elements of a collection. FoldRight is so called because it starts with the last or rightmost 2 items in the collecation and processes backwards towards the initial elements on left side. Since we have been showing recursive examples, here is a recursive implementation of a standalone foldRight that accepts the list to be folded as a parameter:
+but the trickier part is that recursive pattern. It turns out scala has a function for that too in the function 'foldRight'. Folding is a conventional name in most functional languages for a class of higher order functions that combine the elements of a collection. FoldRight is so called because it starts with the last or rightmost 2 items in the collection and processes backwards towards the initial elements on left side. Since we have been showing recursive examples, here is a recursive implementation of a standalone foldRight that accepts the list to be folded as a parameter:
 
 ```scala
 def foldRight[A, B](z:B)(f:(A,B) => B)(l:List[A]): B = l match

--- a/docs/_posts/2023-04-20-functional-modularity-2.md
+++ b/docs/_posts/2023-04-20-functional-modularity-2.md
@@ -117,7 +117,7 @@ In the above example,
 1. We use the `sealed trait` and `Node` `case class` we defined above to restrict what can be matched.
 2. We match on the tree parameter that is passed in, and inside the match we specify two variations of Node to match on.
 3. For the first case we set up a pattern with a Node that has two attributes, `value` and `List()`.
-    - This means that the `tree` object we pass in would need to have something in value, we don't specify what but whatever it is now lives in that `value` variable and the compiler can infer that the object refered to by `value` is goinge to have the parameterized type `A`.
+    - This means that the `tree` object we pass in would need to have something in value, we don't specify what but whatever it is now lives in that `value` variable and the compiler can infer that the object referred to by `value` is goinge to have the parameterized type `A`.
     - We also specify that the first case's `Node` its `children` should be an empty list.
     - If the object pointed to by `tree` meets that pattern, we call our passed in function `f` and pass in the `value` member of our matched `Node`.
 4. For the second case, our `Node` still has a `value` for its `value` member, but then its children needs to be a non-empty list.

--- a/docs/_posts/2023-04-20-functional-modularity-2.md
+++ b/docs/_posts/2023-04-20-functional-modularity-2.md
@@ -117,7 +117,7 @@ In the above example,
 1. We use the `sealed trait` and `Node` `case class` we defined above to restrict what can be matched.
 2. We match on the tree parameter that is passed in, and inside the match we specify two variations of Node to match on.
 3. For the first case we set up a pattern with a Node that has two attributes, `value` and `List()`.
-    - This means that the `tree` object we pass in would need to have something in value, we don't specify what but whatever it is now lives in that `value` variable and the compiler can infer that the object referred to by `value` is goinge to have the parameterized type `A`.
+    - This means that the `tree` object we pass in would need to have something in value, we don't specify what but whatever it is now lives in that `value` variable and the compiler can infer that the object referred to by `value` is going to have the parameterized type `A`.
     - We also specify that the first case's `Node` its `children` should be an empty list.
     - If the object pointed to by `tree` meets that pattern, we call our passed in function `f` and pass in the `value` member of our matched `Node`.
 4. For the second case, our `Node` still has a `value` for its `value` member, but then its children needs to be a non-empty list.

--- a/docs/_posts/2023-04-20-functional-modularity-2.md
+++ b/docs/_posts/2023-04-20-functional-modularity-2.md
@@ -128,7 +128,7 @@ In the above example,
 val treeLineFoldResult: Int = foldTreeLine((a: Int, b: Int) => a + b, 0, treeLine)
 ```
 
-Now we are getting somewhere, this correctly sums the values in the above constrained tree to 6! Before we break out the champagne though, we know this wouldn't work if we had more than one tree in a given `Node`'s `children` member, because we are explictly ignoring the `rest` portion of that pattern match in each case. We've written a function that can handle a very small, very specific subset of the trees we want to be able to fold over, but it doesn't work for all of these trees. Nor does it meet our special requirement, that if we had more than one element in a `Node`'s `children`, we would want to be able to apply a different function than `f`.
+Now we are getting somewhere, this correctly sums the values in the above constrained tree to 6! Before we break out the champagne though, we know this wouldn't work if we had more than one tree in a given `Node`'s `children` member, because we are explicitly ignoring the `rest` portion of that pattern match in each case. We've written a function that can handle a very small, very specific subset of the trees we want to be able to fold over, but it doesn't work for all of these trees. Nor does it meet our special requirement, that if we had more than one element in a `Node`'s `children`, we would want to be able to apply a different function than `f`.
 
 Now we have to try and break down and work on dealing with `rest` as a subroutine. We need a function that can execute a function over a list of trees. I like to start thinking through these problems with a simple example of the data structure, so here is an example of a list of trees:
 


### PR DESCRIPTION
Resolves #48.

Within the dev container, I ran the `spellcheck` shortcut (comes with blog-in-the-box) to reproduce the results locally.

For each one, I then clicked on it and addressed by adding words to the dictionary or fixing the typos.